### PR TITLE
Danglers

### DIFF
--- a/code_style/dot-eslintrc.json
+++ b/code_style/dot-eslintrc.json
@@ -26,6 +26,7 @@
     "import/no-unresolved": [2, { "ignore": ["^meteor/"] }],
     "meteor/eventmap-params": [2, { "templateInstanceParamName": "instance" }],
     "no-console": 1,
+    "no-underscore-dangle": 0,
     "quotes": [2, "double", { "avoidEscape": true, "allowTemplateLiterals": true }],
     "react/no-danger": 1,
     "react/react-in-jsx-scope": 0,

--- a/code_style/dot-eslintrc.json
+++ b/code_style/dot-eslintrc.json
@@ -14,27 +14,21 @@
   "parserOptions": {
     "sourceType": "module",
     "ecmaFeatures": {
-      "jsx": true,
-      "spread": true,
-      "modules": true,
+      "arrowFunctions": true,
       "blockBindings": true,
       "destructuring": true,
-      "arrowFunctions": true
+      "jsx": true,
+      "modules": true,
+      "spread": true
     }
   },
   "rules": {
-    "semi": 2,
+    "import/no-unresolved": [2, { "ignore": ["^meteor/"] }],
+    "meteor/eventmap-params": [2, { "templateInstanceParamName": "instance" }],
     "no-console": 1,
-    "quotes": [
-        2, "double", { "avoidEscape": true, "allowTemplateLiterals": true }
-      ],
+    "quotes": [2, "double", { "avoidEscape": true, "allowTemplateLiterals": true }],
     "react/no-danger": 1,
     "react/react-in-jsx-scope": 0,
-    "meteor/eventmap-params": [
-        2, { "templateInstanceParamName": "instance" }
-      ],
-    "import/no-unresolved": [
-        2, { "ignore": ["^meteor/"] }
-      ]
+    "semi": 2
   }
 }


### PR DESCRIPTION
Meteor uses `_id`. And I think prefixing variable names with underscore to indicate that they're private or dangerous is a useful convention.
