### PR TITLE
Error when import will be undefined

### DIFF
--- a/style-guide/code-style/javascript/.eslintrc
+++ b/style-guide/code-style/javascript/.eslintrc
@@ -7,6 +7,7 @@
     "react/prop-types": 1, // Slows down while prototyping / experimenting
     "max-len": 1, // Sometimes necessary to have long strings and not risk whitespace
     "no-param-reassign": [2, { "props": false }], // Allows assignment of new properties
+    "import/named": 2, // Ensure named imports correspond to a named export in the remote file
   },
   "settings": {
     "import/resolver": "meteor",


### PR DESCRIPTION
This gives a warning when you have a typo or incorrect brackets that will make your import undefined.
