### PR TITLE
refactor: clean up mongo script & update mongo client

### DIFF
--- a/scripts/semaphore-staging-deploy-config
+++ b/scripts/semaphore-staging-deploy-config
@@ -8,14 +8,20 @@ unzip awscli-bundle.zip
 wget -qO- https://toolbelt.heroku.com/install.sh | sh
 # Copy production mongo data to staging
 heroku maintenance:on
-## install mongo 3.2 client so that we can connect to mongo 3.2 server
-wget http://repo.mongodb.org/apt/ubuntu/dists/trusty/mongodb-org/3.2/multiverse/binary-amd64/mongodb-org-tools_3.2.6_amd64.deb
-wget http://repo.mongodb.org/apt/ubuntu/dists/trusty/mongodb-org/3.2/multiverse/binary-amd64/mongodb-org-shell_3.2.6_amd64.deb
-sudo dpkg -i ./mongodb-org-tools_3.2.6_amd64.deb
-sudo dpkg -i ./mongodb-org-shell_3.2.6_amd64.deb
-mongodump --host $PRODUCTION_DB_HOST --port $PRODUCTION_DB_PORT --db $PRODUCTION_DB_NAME -u $PRODUCTION_DB_USERNAME -p $PRODUCTION_DB_PASSWORD -o mongodump
-echo 'db.getCollectionNames().forEach(function(c) {if (c.indexOf("system.") == -1) {db.getCollection(c).drop();}})' | mongo $STAGING_DB_HOST:$STAGING_DB_PORT/$STAGING_DB_NAME -u $STAGING_DB_USERNAME -p $STAGING_DB_PASSWORD
-mongorestore -h $STAGING_DB_HOST:$STAGING_DB_PORT -d $STAGING_DB_NAME -u $STAGING_DB_USERNAME -p $STAGING_DB_PASSWORD mongodump/*
+
+## Install mongo 3.4 client so that we can connect to mongo 3.4 server
+## Note: You should use the same client as your Mongo Server, currently Meteor defaults to 3.4, soon it will 3.6
+wget https://repo.mongodb.org/apt/ubuntu/dists/trusty/mongodb-org/3.4/multiverse/binary-amd64/mongodb-org-tools_3.4.10_amd64.deb
+wget https://repo.mongodb.org/apt/ubuntu/dists/trusty/mongodb-org/3.4/multiverse/binary-amd64/mongodb-org-shell_3.4.10_amd64.deb
+sudo dpkg -i ./mongodb-org-tools_3.4.10_amd64.deb
+sudo dpkg -i ./mongodb-org-shell_3.4.10_amd64.deb
+
+# Dump production db:
+mongodump --host $PRODUCTION_DB_HOST --db $PRODUCTION_DB_NAME --ssl --username $PRODUCTION_DB_USERNAME --password $PRODUCTION_DB_PASSWORD --authenticationDatabase admin --db $PRODUCTION_DB_NAME --verbose --out mongo_dump
+
+# Drop & Restore data (collections) to staging db:
+mongorestore --host $STAGING_DB_HOST --db $STAGING_DB_NAME --username $STAGING_DB_USERNAME --password $STAGING_DB_PASSWORD --ssl --authenticationDatabase admin --drop --verbose mongo_dump/*
+
 # Copy production S3 data to staging
 ~/bin/aws s3 sync --delete --size-only s3://$APPNAME-app-production s3://$APPNAME-app-staging
 heroku maintenance:off


### PR DESCRIPTION
This PR includes the changes made to the script to get our mongodump/mongorestore working and to clean up & simplify the process. 🔥 

**Changes Made:** 💃 
- switched to using 3.4 mongo tool/shell instead of 3.2 & using `https` instead of `http`. Meteor by default now uses `3.4`, next Meteor release will be using `mongo 3.6` and the script will likely be required to be updated again.
- Added comments so others can have a little idea of what is going on.
- Added `--verbose` option so we can see the whole process in the logs and verify the outcome or for debugging upon failure or odd behaviour.
- enabled/enforce `--ssl` as previous versions were not using an ssl connection to dump & restore the db :scream:
- using `--autheniticationDatabase` option to be more clear how the two scripts work
- switched to long form param names to make it more clear what each option is
- Removed unnecessary collection drop script for `--drop` option on `mongorestore` if we wish to be even more restrictive on what we restore we could add the [--nsExclude](https://docs.mongodb.com/manual/reference/program/mongorestore/#cmdoption-mongorestore-nsexclude) or [--nsInclude](https://docs.mongodb.com/manual/reference/program/mongorestore/#cmdoption-mongorestore-nsinclude) options to the `mongorestore` command.
- changed `--out` to `mongo_dump` as `mongodump` is bad naming and can cause confusion as the outpath shared its name with the `mongodump` command